### PR TITLE
fix extra space typo

### DIFF
--- a/scripts/support-sinon.js
+++ b/scripts/support-sinon.js
@@ -8,7 +8,7 @@ var reset = "\u001b[0m";
 
 var output =
     green +
-    "Have some ❤️  for Sinon? You can support the project via Open Collective:" +
+    "Have some ❤️ for Sinon? You can support the project via Open Collective:" +
     white +
     "\n > " +
     boldCyan +


### PR DESCRIPTION
#### Purpose (TL;DR) - mandatory
Fixes a typo in the support sinon message. (an extra space)

#### How to verify - mandatory
1. Check out this branch
2. `npm install`
3. Look at the support message

#### Checklist for author

- [ x] `npm run lint` passes
- [ x] References to standard library functions are [cached](https://github.com/sinonjs/sinon/pull/1523).
